### PR TITLE
refactor-proc-macro

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,11 @@ repository = "https://github.com/jcrist1/tuple_tricks/"
 members = [
     "tuple_tricks",
     "make_tuple_traits",
+    "mark_tuple_traits",
 ]
 
 [dev-dependencies]
-make_tuple_traits = { path = "make_tuple_traits" }
 tuple_tricks = { path = "tuple_tricks"}
+mark_tuple_traits = { path = "mark_tuple_traits" }
 rand = "0.8"
 rand_distr = "0.4"

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ perform tuple tricks you have to mark all of the tuples (up to 32 elements long)
 `proc_macro`: `mark_tuples!(YourMarker)`.
 
 # Building an inductive trait on all tuples.
+(This is duplicated in the `tuple_tricks` crate).
 First you will need to provide all tuples with a marker. This is done with 
 ```rust
 mark_tuples!(MyMarker)
@@ -52,12 +53,23 @@ There is one example of mapping a tuple to a tuple of `Option`. It maps a random
 6-tuple of assorted integer/unsized types to `Some`s, using either the inductive
 trait implemantation (call with `trait`) or with a manual implementation for 
 this specific 6 tuple in this example (call with `manual`). It does this for a 
-randomly generate tuple 1000 times
+randomly generate tuple 100000 times
 ```sh
 cargo run --example tuple_induction {ARGUMENT}
 ```
+The trait based map is not entirely zero cost. As it appears to take about 4% more time.
 
+There is another example which adds `std::ops::Add` to (wrapped) tuples, so one
+can concatenate tuples with `+`:
+```sh
+cargo run --example tuple_addition
+```
 
+# Similar ideas
+I haven't done a very thorough investigation but [frunk](https://github.com/lloydmeta/frunk) 
+seems to do some similar stuff.
+I couldn't quickly see how I could do some stuff in frunk that I can do here (like
+`tuple_addition` example). But that's probably on me. In any case it seems cool.
 # Ideas for next steps
 It would be nice to get non-consuming methods, so we can keep our old tuples around. I'm open to 
 other ideas as issue requests.

--- a/examples/tuple_addition.rs
+++ b/examples/tuple_addition.rs
@@ -2,7 +2,7 @@ use std::ops::Add;
 
 use tuple_tricks::{NestTuple, PreviousTuple, UnnestTuple};
 
-use make_tuple_traits::mark_tuples;
+use mark_tuple_traits::mark_tuples;
 
 mark_tuples!(TupleAdditionMarker);
 

--- a/examples/tuple_induction.rs
+++ b/examples/tuple_induction.rs
@@ -1,4 +1,4 @@
-use make_tuple_traits::mark_tuples;
+use mark_tuple_traits::mark_tuples;
 use rand_distr::Distribution;
 use std::env;
 use tuple_tricks::NestTuple;
@@ -84,7 +84,7 @@ fn main() {
     let mut rng = rand::thread_rng();
     let dist = rand_distr::Uniform::new(0, 128);
     let start = std::time::Instant::now();
-    for _ in 0..10000 {
+    for _ in 0..100000 {
         let a = StructA(dist.sample(&mut rng) as usize);
         let b = StructB(dist.sample(&mut rng) as isize);
         let c = StructC(dist.sample(&mut rng) as i8);

--- a/make_tuple_traits/src/lib.rs
+++ b/make_tuple_traits/src/lib.rs
@@ -30,22 +30,6 @@ impl<{upper_tuple_types}> PreviousTuple for ({upper_tuple_types}) {{
         lower_tail_tuple = tuple_type_list("a", n - 1)
     )
 }
-fn make_next_tuple_type(n: i8) -> String {
-    format!(
-        "
-impl<{upper_tuple_types}> NextTuple for ({upper_tuple_types}) {{
-    type NextTuple<A> = ({upper_tuple_types}, A);
-
-    fn next<A>(self, a: A) -> Self::NextTuple<A> {{
-        let ({lower_tuple}) = self;
-        ({lower_tuple}, a)
-    }}
-}}
-",
-        upper_tuple_types = tuple_type_list("A", n),
-        lower_tuple = tuple_type_list("a", n),
-    )
-}
 
 fn make_nested_tuple(letter: &str, n: i8) -> String {
     (2..(n + 1))
@@ -81,15 +65,6 @@ impl<{upper_tuple_types}> {marker} for ({upper_tuple_types},) {{}}
         upper_tuple_types = tuple_type_list("A", n),
         marker = marker
     )
-}
-
-#[proc_macro]
-pub fn make_next_tuple_types(_item: TokenStream) -> TokenStream {
-    let data = (2..33)
-        .map(make_next_tuple_type)
-        .collect::<Vec<_>>()
-        .join("\n\n");
-    data.parse().expect("Couldn't parse the tuple types")
 }
 
 #[proc_macro]

--- a/mark_tuple_traits/Cargo.toml
+++ b/mark_tuple_traits/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "mark_tuple_traits"
+version = "0.1.0"
+edition = "2018"
+authors = ["Jan Cristina <jan.cristina@gmail.com>"]
+license = "MIT"
+description = "a proc_macro for marking tuples of length up to 32 with a single marker trait to bypass the 'fundamental' feature"
+homepage = "https://github.com/jcrist1/tuple_tricks/mark_tuple_traits"
+repository = "https://github.com/jcrist1/tuple_tricks/mark_tuple_traits"
+keywords = ["tuple", "generic", "proc_macro"]
+readme = "README.md"
+
+
+[lib]
+proc_macro = true
+
+[dependencies]

--- a/mark_tuple_traits/src/lib.rs
+++ b/mark_tuple_traits/src/lib.rs
@@ -1,0 +1,38 @@
+extern crate proc_macro;
+
+use proc_macro::TokenStream;
+
+fn tuple_type_list(letter: &str, n: i8) -> String {
+    (1..(n + 1))
+        .map(|x| format!("{}{}", letter, x))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+fn mark_tuple(n: i8, marker: &str) -> String {
+    format!(
+        "
+impl<{upper_tuple_types}> {marker} for ({upper_tuple_types},) {{}}
+        ",
+        upper_tuple_types = tuple_type_list("A", n),
+        marker = marker
+    )
+}
+
+#[proc_macro]
+pub fn mark_tuples(attr: TokenStream) -> TokenStream {
+    let marker = attr.to_string();
+    format!(
+        "
+pub trait {} {{}}
+{}
+        ",
+        &marker,
+        (2..33)
+            .map(|i| mark_tuple(i, &marker))
+            .collect::<Vec<_>>()
+            .join("\n\n")
+    )
+    .parse()
+    .expect("Couldn't parse marker traits")
+}

--- a/tuple_tricks/README.md
+++ b/tuple_tricks/README.md
@@ -1,0 +1,37 @@
+# Building an inductive trait on all tuples (up to length 32).
+First you will need to provide all tuples with a marker. This is done with 
+```rust
+mark_tuples!(MyMarker)
+```
+Then you define a trait that you want to apply to aa tuples of up to length 32:
+```rust
+trait MyInductiveTrait {
+    type AccumulatedTupleType;
+    fn fn_to_build_accumulated_type_from_self(self) -> Self::AccumulatedTupleType;
+}
+```
+Then define the trait for the one-tuple (i.e. the start of induction)
+```rust
+impl<A> MyInductiveTrait for (A,) {
+    type AccumulatedTupleType = (MyStruct<A>,);
+
+    fn fn_to_build_accumulated_type_from_self(self) -> Self::AccumulatedTupleType {
+        let (a,) = self;
+        (MyStruct::new(a),)
+    }
+}
+```
+The hardest is the induction step, where you will probably need a good many trait bounds:
+```rust
+impl<TupleType, Head, PrevTupleType, PrevAccumulatedTuple> MyInductiveTrait for TupleType
+where
+    TupleType: PreviousTuple<Head = Head, TailTuple = PrevTuple> + MyMarker,
+    // You need the `MyMarker` trait because otherwise the compiler complains about potential
+    // changes to the PreviousTuple implementation.
+    PrevTuple: MyInductiveTrait<AccumulatedTupleType = PrevAccumulatedTuple>,
+    PrevAccumulatedTuple: NestTuple,
+    (PrevAccumulatedTuple::Nested, MyStruct<Head>): UnnestTuple
+{
+    ...
+}
+```

--- a/tuple_tricks/src/lib.rs
+++ b/tuple_tricks/src/lib.rs
@@ -1,4 +1,3 @@
-extern crate make_tuple_traits;
 use make_tuple_traits::{make_prev_tuple_types, make_unnest_traits};
 
 pub trait PreviousTuple {


### PR DESCRIPTION
A simple refactor.  Make the proc macros that don't need to be public, not necessarily public.